### PR TITLE
Us9 api holidays

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'hirb'
+  gem 'httparty'
+  gem 'json'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,8 +75,12 @@ GEM
     globalid (1.0.0)
       activesupport (>= 5.0)
     hirb (0.7.3)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    json (2.6.3)
     launchy (2.5.2)
       addressable (~> 2.8)
     listen (3.1.5)
@@ -96,6 +100,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.17.0)
+    multi_xml (0.6.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -120,7 +125,7 @@ GEM
     public_suffix (5.0.1)
     puma (3.12.6)
     racc (1.6.2)
-    rack (2.2.5)
+    rack (2.2.6)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (5.2.8.1)
@@ -161,7 +166,7 @@ GEM
     rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.2)
+    rspec-mocks (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-rails (4.0.2)
@@ -225,6 +230,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   hirb
+  httparty
+  json
   launchy
   listen (>= 3.0.5, < 3.2)
   orderly

--- a/app/services/api/date/date_service.rb
+++ b/app/services/api/date/date_service.rb
@@ -1,0 +1,11 @@
+require_relative './holiday.rb'
+
+module Api
+  module Date
+    class DateService
+      def self.date_api_holidays
+        Holiday.new.next_three
+      end
+    end
+  end
+end

--- a/app/services/api/date/holiday.rb
+++ b/app/services/api/date/holiday.rb
@@ -1,0 +1,19 @@
+require 'httparty'
+require 'json'
+
+class Holiday
+  def initialize
+  end
+
+  def response
+    HTTParty.get("https://date.nager.at/api/v3/NextPublicHolidays/US")
+  end
+
+  def parsed
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def next_three
+    parsed.first(3)
+  end
+end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -13,3 +13,12 @@
     </div>
   <% end %>
 <% end %>
+
+<div id="next-3-holidays" >
+  <h2>Next Three Holidays</h2>
+  <% Api::Date::DateService.date_api_holidays.each do |holiday| %>
+    <ul>
+      <li><%= "#{holiday[:name]}: #{holiday[:date]}" %></li>
+    </ul>
+  <% end %>
+</div>

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -117,6 +117,17 @@ RSpec.describe 'merchant discount index' do
           expect(page).to_not have_content("Id: #{@bulk_discount_1.id}")
         end
       end
+
+      describe 'section with a header of "Upcoming Holidays"' do
+        it 'lists name and date of the next 3 upcoming US holidays' do
+          within("#next-3-holidays") do
+            expect(page).to have_content("Next Three Holidays")
+            expect(page).to have_content("Washington's Birthday: 2023-02-20")
+            expect(page).to have_content("Good Friday: 2023-04-07")
+            expect(page).to have_content("Memorial Day: 2023-05-29")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Completes User Story 9:
API request sent to "https://date.nager.at/api/v3/NextPublicHolidays/US" to acquire the next three upcoming holidays
Displays returned holiday's names and dates on the Merchant Bulk Discount Index page